### PR TITLE
Add wildcard at beginning of sed replace string

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -114,7 +114,7 @@ module.exports = -> _.assign @,
       if code is 0
         @then @log "Matching line found, replacing..."
         ver = tmp_file file
-        @then @execute "sed #{bash_esc "s/#{o.find}.*/#{bash_esc o.replace}/"} #{bash_esc file} > #{bash_esc "/tmp/remote-#{ver}"}", _.merge o, test: ({code}) =>
+        @then @execute "sed #{bash_esc "s/.*#{o.find}.*/#{bash_esc o.replace}/"} #{bash_esc file} > #{bash_esc "/tmp/remote-#{ver}"}", _.merge o, test: ({code}) =>
           @then @execute "mv #{bash_esc "/tmp/remote-#{ver}"} #{bash_esc file}", _.merge o, test: ({code}) =>
             @then @die "FATAL ERROR: unable to replace line." unless code is 0
       else


### PR DESCRIPTION
Function should replace the entire line, including characters before the search string, particularly '#' if it's commented out
